### PR TITLE
add CI/CD

### DIFF
--- a/ci-cd.tf
+++ b/ci-cd.tf
@@ -1,0 +1,45 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_project_service" "ci_cd" {
+  project = google_project.prj.name
+  service = "${each.value}.googleapis.com"
+
+  for_each = toset([
+    "artifactregistry",
+    "sourcerepo",
+    "storage",
+  ])
+}
+
+resource "google_artifact_registry_repository" "repo" {
+  project  = google_project.prj.name
+  location = var.google_cloud_region
+
+  repository_id = "repo"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.ci_cd["artifactregistry"]]
+}
+
+locals {
+  image_path = "${var.google_cloud_region}-docker.pkg.dev/${google_project.prj.name}/${google_artifact_registry_repository.repo.name}/demo"
+}
+
+resource "google_sourcerepo_repository" "repo" {
+  project = google_project.prj.name
+  name    = "repo"
+
+  depends_on = [google_project_service.ci_cd["sourcerepo"]]
+}

--- a/ci-cd.tf
+++ b/ci-cd.tf
@@ -19,6 +19,7 @@ resource "google_project_service" "ci_cd" {
   for_each = toset([
     "artifactregistry",
     "cloudbuild",
+    "iam",
     "sourcerepo",
     "storage",
   ])

--- a/ci-cd.tf
+++ b/ci-cd.tf
@@ -89,7 +89,7 @@ resource "google_cloudbuild_trigger" "demo" {
 
   trigger_template {
     repo_name   = google_sourcerepo_repository.repo.name
-    branch_name = "."
+    branch_name = "^main$"
   }
 
   build {

--- a/ci-cd.tf
+++ b/ci-cd.tf
@@ -128,4 +128,11 @@ resource "google_cloudbuild_trigger" "demo" {
       ]
     }
   }
+
+  depends_on = [
+    google_project_service.ci_cd["cloudbuild"],
+
+    # wait for the service enablement to propagate before creating trigger
+    time_sleep.wait_for_services,
+  ]
 }

--- a/ci-cd.tf
+++ b/ci-cd.tf
@@ -44,12 +44,16 @@ resource "google_project_iam_member" "build_run_developer" {
   project = google_project.prj.name
   role   = "roles/run.developer"
   member = "serviceAccount:${google_project.prj.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [google_project_service.ci_cd["cloudbuild"]]
 }
 
 resource "google_project_iam_member" "build_act_as" {
   project = google_project.prj.name
   role   = "roles/iam.serviceAccountUser"
   member = "serviceAccount:${google_project.prj.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [google_project_service.ci_cd["cloudbuild"]]
 }
 
 resource "google_artifact_registry_repository" "repo" {

--- a/google.tf
+++ b/google.tf
@@ -56,6 +56,12 @@ resource "google_cloud_run_service" "app" {
     }
   }
 
+  lifecycle {
+    # this stops terraform from trying to revert to the sample app after you've
+    # pushed new changes through CI
+    ignore_changes = [template[0].spec[0].containers[0].image]
+  }
+
   depends_on = [google_project_service.svc["run"]]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,3 +15,7 @@
 output "app_url" {
   value = google_cloud_run_service.app.status[0].url
 }
+
+output "repo_url" {
+  value = google_sourcerepo_repository.repo.url
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "project_name" {
   default     = "gcp-meanstack-demo"
 }
 
+variable "enable_ci_cd_pipline" {
+  type        = bool
+  description = "whether to build and enable a CI/CD pipeline in your project"
+  default     = false
+}
+
 ###-----------------------------------------------------------------------------
 ### region config
 ###-----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -22,12 +22,6 @@ variable "project_name" {
   default     = "gcp-meanstack-demo"
 }
 
-variable "enable_ci_cd_pipline" {
-  type        = bool
-  description = "whether to build and enable a CI/CD pipeline in your project"
-  default     = false
-}
-
 ###-----------------------------------------------------------------------------
 ### region config
 ###-----------------------------------------------------------------------------


### PR DESCRIPTION
Updates the Terraform code to deploy a CI/CD pipeline for the demo application. See discussion in #15.

- [X] create Cloud Source Repository repo as a push-to-deploy target
- [X] create build trigger that runs `npm test`
- [X] update trigger to push image
- [X] update trigger to deploy to cloud run

/closes #15